### PR TITLE
Add support for continuing after the first match

### DIFF
--- a/src/crack/result.rs
+++ b/src/crack/result.rs
@@ -46,7 +46,7 @@ pub struct CrackResult {
 
 impl CrackResult {
     fn new<T: CrackTarget>(
-        cp: InternalCrackParameter<T>,
+        cp: &InternalCrackParameter<T>,
         duration_in_seconds: f64,
         solution: Option<String>,
     ) -> Self {
@@ -63,14 +63,14 @@ impl CrackResult {
     }
 
     pub(crate) fn new_failure<T: CrackTarget>(
-        cp: InternalCrackParameter<T>,
+        cp: &InternalCrackParameter<T>,
         seconds_as_fraction: f64,
     ) -> Self {
         Self::new(cp, seconds_as_fraction, None)
     }
 
     pub(crate) fn new_success<T: CrackTarget>(
-        cp: InternalCrackParameter<T>,
+        cp: &InternalCrackParameter<T>,
         seconds_as_fraction: f64,
         solution: String,
     ) -> Self {
@@ -91,8 +91,8 @@ impl CrackResult {
 
     /// Returns the solution, if any.
     #[must_use]
-    pub const fn solution(&self) -> &Option<String> {
-        &self.solution
+    pub fn solution(&self) -> Option<&str> {
+        self.solution.as_deref()
     }
 
     /// Returns the number of threads that were used.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,11 @@ SOFTWARE.
 
 use crate::crack::worker_threads::spawn_worker_threads;
 use std::fmt::Debug;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Receiver, RecvError, RecvTimeoutError};
 use std::sync::Arc;
-use std::time::Instant;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 pub use crack::CrackResult;
 pub use parameter::*;
@@ -84,21 +86,23 @@ pub mod hash_fncs;
 mod parameter;
 pub mod symbols;
 
-/// Common trait for crack targets (hashes or plain text to crack). This is the super-type
-/// which enables the usage of multiple hashing algorithms. An example that
-/// implements this/fulfils the trait requirements is [`String`].
+/// Common trait for crack targets (hashes or plain text to crack).
+///
+/// This is the super-type which enables the usage of multiple hashing algorithms.
+/// An example that implements this/fulfils the trait requirements is [`String`].
 // 'static:
 //  - it means the type does not contain any non-static references; i.e. consumes can
 //    own implementers of this type easily
 //  - https://doc.rust-lang.org/rust-by-example/scope/lifetime/static_lifetime.html
-pub trait CrackTarget: 'static + Eq + Send + Sync + Debug {}
+pub trait CrackTarget: 'static + Eq + Send + Sync + Debug + Clone {}
 
 // automatically impl the trait for all types that fulfill the condition/required traits
-impl<T> CrackTarget for T where T: 'static + Eq + Send + Sync + Debug {}
+impl<T> CrackTarget for T where T: 'static + Eq + Send + Sync + Debug + Clone {}
 
-/// This function starts a multi-threaded brute force attack on a given target string. It supports
-/// any alphabet you would like to use. You must provide a hashing function. There is a pre-build
-/// set of transformation functions available, such as [`hash_fncs::no_hashing`] or
+/// Start a multi-threaded brute force attack on a given target string.
+///
+/// It supports any alphabet you would like to use. You must provide a hashing function.
+/// There is a pre-build set of transformation functions available, such as [`hash_fncs::no_hashing`] or
 /// [`hash_fncs::sha256_hashing`]. You can also provide your own hashing strategy.
 ///
 /// This library is really "dumb". It checks each possible value and doesn't use any probabilities
@@ -117,23 +121,147 @@ pub fn crack<T: CrackTarget>(param: CrackParameter<T>) -> CrackResult {
     // so they can stop their work. This only gets checked at every millionth iteration
     // for better performance.
     let done = Arc::from(AtomicBool::from(false));
-    let instant = Instant::now();
-    let handles = spawn_worker_threads(param.clone(), done);
+    // solutions are send over the channel
+    // when the sender channels are closed, the threads haven't found a solution
+    let (sender, receiver) = channel();
 
-    // wait for all threads
-    let solution = handles
-        .into_iter()
-        .flat_map(|h| h.join().unwrap()) // result of the Option<String> from the threads
-        .last(); // extract from the collection
+    let instant = Instant::now();
+    let handles = spawn_worker_threads(param.clone(), sender, done.clone());
+
+    let solution = match receiver.recv() {
+        Ok(solution) => Some(solution),
+        Err(RecvError) => None,
+    };
+    done.store(true, Ordering::Relaxed);
+    // if we don't drop the receiver, the threads will keep searching
+    drop(receiver);
 
     let seconds = instant.elapsed().as_secs_f64();
 
+    // wait for all threads to actually finish
+    handles.into_iter().for_each(|h| h.join().unwrap());
+
     let param =
         Arc::try_unwrap(param).unwrap_or_else(|_| panic!("There should only be one reference!"));
-    if let Some(solution) = solution {
-        CrackResult::new_success(param, seconds, solution)
-    } else {
-        CrackResult::new_failure(param, seconds)
+    solution.map_or_else(
+        || CrackResult::new_failure(&param, seconds),
+        |solution| CrackResult::new_success(&param, seconds, solution),
+    )
+}
+
+/// Starts a multi-threaded brute force attack on a given target string that keeps search after a match.
+///
+/// This variant of [`crack`] is useful for weak hash functions, where you need the original value
+/// but there are many matches for a hash.
+///
+/// It supports any alphabet you would like to use. You must provide a hashing function.
+/// There is a pre-build set of transformation functions available, such as [`hash_fncs::no_hashing`] or
+/// [`hash_fncs::sha256_hashing`]. You can also provide your own hashing strategy.
+///
+/// This library is really "dumb". It checks each possible value and doesn't use any probabilities
+/// for more or less probable passwords.
+///
+/// # Parameters
+/// * `param` - See [`CrackParameter`]
+///
+/// # Return
+/// Returns a [`CrackResult`].
+pub fn crack_iter<T: CrackTarget>(param: CrackParameter<T>) -> CrackResults<T> {
+    let param = InternalCrackParameter::from(param);
+    let param = Arc::from(param);
+
+    // shared atomic bool so that all threads can look if one already found a solution
+    // so they can stop their work. This only gets checked at every millionth iteration
+    // for better performance.
+    let done = Arc::from(AtomicBool::from(false));
+    // solutions are send over the channel
+    // when the sender channels are closed, the threads haven't found a solution
+    let (sender, receiver) = channel();
+
+    let start = Instant::now();
+    let handles = spawn_worker_threads(param.clone(), sender, done.clone());
+
+    CrackResults {
+        receiver,
+        done,
+        handles,
+        start,
+        param,
+    }
+}
+
+#[derive(Debug)]
+pub struct CrackResults<T: CrackTarget> {
+    receiver: Receiver<String>,
+    done: Arc<AtomicBool>,
+    handles: Vec<JoinHandle<()>>,
+    start: Instant,
+    param: Arc<InternalCrackParameter<T>>,
+}
+
+impl<T: CrackTarget> Iterator for CrackResults<T> {
+    type Item = CrackResult;
+
+    /// This call is blocking.
+    ///
+    /// For the non-blocking variant, use
+    /// [`try_next`]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.receiver.recv() {
+            Ok(solution) => {
+                let seconds = self.start.elapsed().as_secs_f64();
+                Some(CrackResult::new_success(&self.param, seconds, solution))
+            }
+            Err(RecvError) => {
+                // all senders are closed so this shouldn't be necessary, but just in case
+                self.done.store(true, Ordering::Relaxed);
+                // cleanup all the handles
+                while let Some(handle) = self.handles.pop() {
+                    handle.join().unwrap();
+                }
+                None
+            }
+        }
+    }
+}
+
+impl<T: CrackTarget> CrackResults<T> {
+    /// Attempts to wait for a result, returning `Ok(None)` if there is still progress.
+    ///
+    /// Will return `Err(CrackResult)` if all the threads are done.
+    pub fn next_timeout(&mut self, timeout: Duration) -> Result<Option<CrackResult>, CrackResult> {
+        match self.receiver.recv_timeout(timeout) {
+            Ok(solution) => {
+                let seconds = self.start.elapsed().as_secs_f64();
+                Ok(Some(CrackResult::new_success(
+                    &self.param,
+                    seconds,
+                    solution,
+                )))
+            }
+            Err(RecvTimeoutError::Timeout) => Ok(None),
+            Err(RecvTimeoutError::Disconnected) => {
+                // all senders are closed so this shouldn't be necessary, but just in case
+                self.done.store(true, Ordering::Relaxed);
+                // cleanup all the handles
+                while let Some(handle) = self.handles.pop() {
+                    handle.join().unwrap();
+                }
+
+                let seconds = self.start.elapsed().as_secs_f64();
+                Err(CrackResult::new_failure(&self.param, seconds))
+            }
+        }
+    }
+
+    /// Stop search for a match
+    pub fn stop(&mut self) {
+        // stop all the threads
+        self.done.store(true, Ordering::Relaxed);
+        // cleanup all the handles
+        while let Some(handle) = self.handles.pop() {
+            handle.join().unwrap();
+        }
     }
 }
 
@@ -198,7 +326,7 @@ mod tests {
         let res = crack(cp);
         assert!(res.is_success(), "A solution MUST be found!");
         assert!(
-            input.eq(res.solution().as_ref().unwrap()),
+            input.eq(res.solution().unwrap()),
             "The cracked value is wrong! It's"
         );
 
@@ -209,7 +337,7 @@ mod tests {
             let res_fair = crack(cp_fair);
             assert!(res_fair.is_success(), "A solution MUST be found!");
             assert!(
-                input.eq(res.solution().as_ref().unwrap()),
+                input.eq(res.solution().unwrap()),
                 "The cracked value is wrong!"
             );
             assert!(

--- a/src/parameter/basic.rs
+++ b/src/parameter/basic.rs
@@ -38,7 +38,12 @@ pub struct BasicCrackParameter {
 impl BasicCrackParameter {
     /// Constructor.
     #[must_use]
-    pub fn new(alphabet: Box<[char]>, max_length: u32, min_length: u32, fair_mode: bool) -> Self {
+    pub const fn new(
+        alphabet: Box<[char]>,
+        max_length: u32,
+        min_length: u32,
+        fair_mode: bool,
+    ) -> Self {
         Self {
             alphabet,
             max_length,

--- a/src/parameter/mod.rs
+++ b/src/parameter/mod.rs
@@ -44,9 +44,10 @@ pub use target_hash::*;
 pub(crate) use internal::get_thread_count;
 pub(crate) use internal::InternalCrackParameter;
 
-/// Crack parameter for `crate::crack<T: CrackTarget>()`. It combines the basic struct
-/// [`BasicCrackParameter`] with the generic [`TargetHashAndHashFunction`]. This separation exists
-/// so that hash selection functions can be written more convenient.
+/// Crack parameter for `crate::crack<T: CrackTarget>()`.
+///
+/// It combines the basic struct [`BasicCrackParameter`] with the generic [`TargetHashAndHashFunction`].
+/// This separation exists so that hash selection functions can be written more convenient.
 ///
 /// ```rust
 /// use libbruteforce::{BasicCrackParameter, CrackParameter, TargetHashInput};

--- a/src/parameter/target_hash.rs
+++ b/src/parameter/target_hash.rs
@@ -36,6 +36,7 @@ pub enum TargetHashInput<'a> {
 }
 
 /// Abstraction over a hashing algorithm and the target hash that needs to be cracked.
+///
 /// `T` is of type [`CrackTarget`]. This generic struct exists so that hashes of type
 /// [`CrackTarget`] can be checked independent of the hashing algorithm. This is
 /// more efficient than transforming every hash to a string and compare the hash


### PR DESCRIPTION
This is primarily useful for cases where the original value is important and the hash used is weak (or not even a real hash like a CRC).

I've added a channel to send the results to the main thread. Because it's not possible to check if a channel is still open, the signal boolean is still needed. In the normal case (`crack`), this does mean that the threads will continue after the first match until the main thread sets the signal boolean.